### PR TITLE
fix(deploy): allow GraphQL POST through Traefik

### DIFF
--- a/deploy/docker/compose.server.secure.yml
+++ b/deploy/docker/compose.server.secure.yml
@@ -48,7 +48,11 @@ services:
       - "traefik.http.services.libms.loadbalancer.server.port=4001"
       - "traefik.http.routers.libms.rule=Host(`${SERVER_DNS}`)&&PathPrefix(`/lib`)"
       - "traefik.http.routers.libms.tls=true"
-      - "traefik.http.routers.libms.middlewares=traefik-forward-auth"
+      - "traefik.http.routers.libms.middlewares=libms-cors,traefik-forward-auth"
+      - "traefik.http.middlewares.libms-cors.headers.accessControlAllowOriginList=http://localhost,http://host.docker.internal,http://${SERVER_DNS},https://${SERVER_DNS}"
+      - "traefik.http.middlewares.libms-cors.headers.accessControlAllowMethods=GET,POST,OPTIONS"
+      - "traefik.http.middlewares.libms-cors.headers.accessControlAllowHeaders=Authorization,Content-Type"
+      - "traefik.http.middlewares.libms-cors.headers.accessControlAllowCredentials=true"
     networks:
       - frontend
 

--- a/deploy/docker/compose.server.secure.yml
+++ b/deploy/docker/compose.server.secure.yml
@@ -49,7 +49,7 @@ services:
       - "traefik.http.routers.libms.rule=Host(`${SERVER_DNS}`)&&PathPrefix(`/lib`)"
       - "traefik.http.routers.libms.tls=true"
       - "traefik.http.routers.libms.middlewares=libms-cors,traefik-forward-auth"
-      - "traefik.http.middlewares.libms-cors.headers.accessControlAllowOriginList=http://localhost,http://host.docker.internal,http://${SERVER_DNS},https://${SERVER_DNS}"
+      - "traefik.http.middlewares.libms-cors.headers.accessControlAllowOriginList=http://${SERVER_DNS},http://${SERVER_DNS}:80,https://${SERVER_DNS},https://${SERVER_DNS}:443"
       - "traefik.http.middlewares.libms-cors.headers.accessControlAllowMethods=GET,POST,OPTIONS"
       - "traefik.http.middlewares.libms-cors.headers.accessControlAllowHeaders=Authorization,Content-Type"
       - "traefik.http.middlewares.libms-cors.headers.accessControlAllowCredentials=true"

--- a/deploy/docker/compose.server.yml
+++ b/deploy/docker/compose.server.yml
@@ -28,7 +28,7 @@ services:
       - "traefik.http.services.libms.loadbalancer.server.port=4001"
       - "traefik.http.routers.libms.rule=Host(`${SERVER_DNS}`)&&PathPrefix(`/lib`)"
       - "traefik.http.routers.libms.middlewares=libms-cors,traefik-forward-auth"
-      - "traefik.http.middlewares.libms-cors.headers.accessControlAllowOriginList=http://localhost,http://host.docker.internal,http://${SERVER_DNS},https://${SERVER_DNS}"
+      - "traefik.http.middlewares.libms-cors.headers.accessControlAllowOriginList=http://${SERVER_DNS},http://${SERVER_DNS}:80,https://${SERVER_DNS},https://${SERVER_DNS}:443"
       - "traefik.http.middlewares.libms-cors.headers.accessControlAllowMethods=GET,POST,OPTIONS"
       - "traefik.http.middlewares.libms-cors.headers.accessControlAllowHeaders=Authorization,Content-Type"
       - "traefik.http.middlewares.libms-cors.headers.accessControlAllowCredentials=true"

--- a/deploy/docker/compose.server.yml
+++ b/deploy/docker/compose.server.yml
@@ -27,7 +27,11 @@ services:
       - "traefik.http.routers.libms.entryPoints=web"
       - "traefik.http.services.libms.loadbalancer.server.port=4001"
       - "traefik.http.routers.libms.rule=Host(`${SERVER_DNS}`)&&PathPrefix(`/lib`)"
-      - "traefik.http.routers.libms.middlewares=traefik-forward-auth"
+      - "traefik.http.routers.libms.middlewares=libms-cors,traefik-forward-auth"
+      - "traefik.http.middlewares.libms-cors.headers.accessControlAllowOriginList=http://localhost,http://host.docker.internal,http://${SERVER_DNS},https://${SERVER_DNS}"
+      - "traefik.http.middlewares.libms-cors.headers.accessControlAllowMethods=GET,POST,OPTIONS"
+      - "traefik.http.middlewares.libms-cors.headers.accessControlAllowHeaders=Authorization,Content-Type"
+      - "traefik.http.middlewares.libms-cors.headers.accessControlAllowCredentials=true"
     networks:
       - frontend
 


### PR DESCRIPTION
Add a dedicated libms CORS middleware to the deploy/docker server compose files and allow POST requests for GraphQL behind Traefik.
