### PR TITLE
feat(client): robust username selection from OAuth JWT claims

### DIFF
--- a/client/src/route/account/AccountTabData.tsx
+++ b/client/src/route/account/AccountTabData.tsx
@@ -3,7 +3,6 @@ import { useAuth } from 'react-oidc-context';
 import { TabData } from 'components/tab/subcomponents/TabRender';
 import SettingsForm from 'route/account/SettingsForm';
 import {
-  resolveOAuthDisplayName,
   resolveOAuthProfileUrl,
   resolveOAuthUsername,
 } from 'util/auth/oauthUserProfile';
@@ -52,14 +51,13 @@ function GroupParagraph(groups: string[], name: ReactNode) {
 function ProfileTab() {
   const { user } = useAuth();
   const username = resolveOAuthUsername(user?.profile);
-  const name = resolveOAuthDisplayName(user?.profile, username);
   const pfp = user?.profile.picture;
   const profileUrl = resolveOAuthProfileUrl(user?.profile);
 
   const groups = (user?.profile.groups as string[] | string | undefined) ?? [];
   const isGroupsAString = typeof groups === 'string';
   const groupsArray = isGroupsAString ? [groups] : groups;
-  const groupParagraph = GroupParagraph(groupsArray, name);
+  const groupParagraph = GroupParagraph(groupsArray, username);
   const profileSettingsText = (
     <>
       You can edit your profile details and change password on{' '}
@@ -79,7 +77,7 @@ function ProfileTab() {
       <h2>Profile</h2>
       <img src={pfp} alt="Avatar" data-testid="profile-picture" />
       <p>
-        The username is <b>{name}</b>.{' '}
+        The username is <b>{username}</b>.{' '}
         {profileUrl ? profileSettingsText : profileNotAvailableText}
       </p>
       {groupParagraph}

--- a/client/src/route/account/AccountTabData.tsx
+++ b/client/src/route/account/AccountTabData.tsx
@@ -2,6 +2,11 @@ import { createElement, Children, ReactNode } from 'react';
 import { useAuth } from 'react-oidc-context';
 import { TabData } from 'components/tab/subcomponents/TabRender';
 import SettingsForm from 'route/account/SettingsForm';
+import {
+  resolveOAuthDisplayName,
+  resolveOAuthProfileUrl,
+  resolveOAuthUsername,
+} from 'util/auth/oauthUserProfile';
 
 function ListGroups(groups: string[]): ReactNode[] {
   const boldGroups = groups.map((group) =>
@@ -46,27 +51,36 @@ function GroupParagraph(groups: string[], name: ReactNode) {
 
 function ProfileTab() {
   const { user } = useAuth();
-  const name = user?.profile.preferred_username ?? '';
+  const username = resolveOAuthUsername(user?.profile);
+  const name = resolveOAuthDisplayName(user?.profile, username);
   const pfp = user?.profile.picture;
-  const profileUrl = user?.profile.profile;
+  const profileUrl = resolveOAuthProfileUrl(user?.profile);
 
   const groups = (user?.profile.groups as string[] | string | undefined) ?? [];
   const isGroupsAString = typeof groups === 'string';
   const groupsArray = isGroupsAString ? [groups] : groups;
   const groupParagraph = GroupParagraph(groupsArray, name);
+  const profileSettingsText = (
+    <>
+      You can edit your profile details and change password on{' '}
+      <b>
+        <a href={profileUrl} target="_blank" rel="noreferrer">
+          SSO OAuth Provider.
+        </a>
+      </b>
+    </>
+  );
+  const profileNotAvailableText = (
+    <>Your OAuth provider did not expose a profile URL.</>
+  );
 
   return (
     <div>
       <h2>Profile</h2>
       <img src={pfp} alt="Avatar" data-testid="profile-picture" />
       <p>
-        The username is <b>{name}</b>. You can edit your profile details and
-        change password on{' '}
-        <b>
-          <a href={profileUrl} target="_blank" rel="noreferrer">
-            SSO OAuth Provider.
-          </a>
-        </b>
+        The username is <b>{name}</b>.{' '}
+        {profileUrl ? profileSettingsText : profileNotAvailableText}
       </p>
       {groupParagraph}
     </div>
@@ -74,16 +88,19 @@ function ProfileTab() {
 }
 
 function SettingsTab() {
-  const profileUrl = useAuth().user?.profile.profile;
+  const profileUrl = resolveOAuthProfileUrl(useAuth().user?.profile);
+  const profileSettingsText = profileUrl ? (
+    <b>
+      <a href={profileUrl}>SSO OAuth Provider.</a>
+    </b>
+  ) : (
+    'your SSO OAuth Provider account page.'
+  );
+
   return (
     <div>
       <h2>Settings</h2>
-      <p>
-        Edit the profile on{' '}
-        <b>
-          <a href={profileUrl}>SSO OAuth Provider.</a>
-        </b>
-      </p>
+      <p>Edit the profile on {profileSettingsText}</p>
 
       <SettingsForm />
     </div>

--- a/client/src/util/auth/Authentication.ts
+++ b/client/src/util/auth/Authentication.ts
@@ -3,6 +3,7 @@ import { useDispatch } from 'react-redux';
 import { setUserName } from 'store/auth.slice';
 import { AuthContextProps } from 'react-oidc-context';
 import { getLogoutRedirectURI, useAppURL, cleanURL } from 'util/envUtil';
+import { resolveOAuthUsername } from 'util/auth/oauthUserProfile';
 
 export interface CustomAuthContext {
   signoutRedirect: () => Promise<void>;
@@ -18,9 +19,8 @@ export function useGetAndSetUsername() {
     if (!auth.user) {
       return;
     }
-    const profileUrl = auth.user.profile.profile ?? '';
-    const username = profileUrl.split('/').filter(Boolean).pop() ?? '';
-    sessionStorage.setItem('username', username ?? '');
+    const username = resolveOAuthUsername(auth.user.profile);
+    sessionStorage.setItem('username', username);
     dispatch(setUserName(username));
   };
   return getAndSetUsername;

--- a/client/src/util/auth/oauthUserProfile.ts
+++ b/client/src/util/auth/oauthUserProfile.ts
@@ -36,8 +36,13 @@ function getUsernameFromProfileUrl(
   if (!profileUrl) {
     return undefined;
   }
-  const pathWithoutQuery = profileUrl.split('?')[0]?.split('#')[0] ?? '';
-  const pathSegments = pathWithoutQuery.split('/').filter(Boolean);
+  let pathname: string;
+  try {
+    pathname = new URL(profileUrl).pathname;
+  } catch {
+    return undefined;
+  }
+  const pathSegments = pathname.split('/').filter(Boolean);
   const username = pathSegments.at(-1)?.trim();
   return username && username.length > 0 ? username : undefined;
 }

--- a/client/src/util/auth/oauthUserProfile.ts
+++ b/client/src/util/auth/oauthUserProfile.ts
@@ -8,6 +8,7 @@ const USERNAME_CLAIM_PRIORITY = [
 ] as const;
 
 const PROFILE_URL_CLAIM_PRIORITY = ['profile', 'html_url'] as const;
+const ALLOWED_PROFILE_URL_PROTOCOLS = new Set(['http:', 'https:']);
 
 function getClaim(profile: OAuthProfile, claim: string): string | undefined {
   if (!profile) {
@@ -29,7 +30,9 @@ function getEmailLocalPart(identifier: string | undefined): string | undefined {
   return localPart && localPart.length > 0 ? localPart : undefined;
 }
 
-function getUsernameFromProfileUrl(profileUrl: string | undefined): string | undefined {
+function getUsernameFromProfileUrl(
+  profileUrl: string | undefined,
+): string | undefined {
   if (!profileUrl) {
     return undefined;
   }
@@ -39,8 +42,19 @@ function getUsernameFromProfileUrl(profileUrl: string | undefined): string | und
   return username && username.length > 0 ? username : undefined;
 }
 
-function firstDefinedValue(values: Array<string | undefined>): string | undefined {
+function firstDefinedValue(
+  values: Array<string | undefined>,
+): string | undefined {
   return values.find((value) => value !== undefined);
+}
+
+function isSafeExternalUrl(urlValue: string): boolean {
+  try {
+    const parsedUrl = new URL(urlValue);
+    return ALLOWED_PROFILE_URL_PROTOCOLS.has(parsedUrl.protocol);
+  } catch {
+    return false;
+  }
 }
 
 export function resolveOAuthUsername(profile: OAuthProfile): string {
@@ -79,5 +93,9 @@ export function resolveOAuthProfileUrl(
   const profileClaimValues = PROFILE_URL_CLAIM_PRIORITY.map((claim) =>
     getClaim(profile, claim),
   );
-  return firstDefinedValue(profileClaimValues);
+  const profileUrl = firstDefinedValue(profileClaimValues);
+  if (!profileUrl) {
+    return undefined;
+  }
+  return isSafeExternalUrl(profileUrl) ? profileUrl : undefined;
 }

--- a/client/src/util/auth/oauthUserProfile.ts
+++ b/client/src/util/auth/oauthUserProfile.ts
@@ -38,7 +38,7 @@ function getUsernameFromProfileUrl(
   }
   const pathWithoutQuery = profileUrl.split('?')[0]?.split('#')[0] ?? '';
   const pathSegments = pathWithoutQuery.split('/').filter(Boolean);
-  const username = pathSegments[pathSegments.length - 1]?.trim();
+  const username = pathSegments.at(-1)?.trim();
   return username && username.length > 0 ? username : undefined;
 }
 

--- a/client/src/util/auth/oauthUserProfile.ts
+++ b/client/src/util/auth/oauthUserProfile.ts
@@ -1,0 +1,83 @@
+type OAuthProfile = Record<string, unknown> | null | undefined;
+
+const USERNAME_CLAIM_PRIORITY = [
+  'preferred_username',
+  'username',
+  'nickname',
+  'login',
+] as const;
+
+const PROFILE_URL_CLAIM_PRIORITY = ['profile', 'html_url'] as const;
+
+function getClaim(profile: OAuthProfile, claim: string): string | undefined {
+  if (!profile) {
+    return undefined;
+  }
+  const claimValue = profile[claim];
+  if (typeof claimValue !== 'string') {
+    return undefined;
+  }
+  const trimmedClaimValue = claimValue.trim();
+  return trimmedClaimValue.length > 0 ? trimmedClaimValue : undefined;
+}
+
+function getEmailLocalPart(identifier: string | undefined): string | undefined {
+  if (!identifier) {
+    return undefined;
+  }
+  const localPart = identifier.split('@')[0]?.trim();
+  return localPart && localPart.length > 0 ? localPart : undefined;
+}
+
+function getUsernameFromProfileUrl(profileUrl: string | undefined): string | undefined {
+  if (!profileUrl) {
+    return undefined;
+  }
+  const pathWithoutQuery = profileUrl.split('?')[0]?.split('#')[0] ?? '';
+  const pathSegments = pathWithoutQuery.split('/').filter(Boolean);
+  const username = pathSegments[pathSegments.length - 1]?.trim();
+  return username && username.length > 0 ? username : undefined;
+}
+
+function firstDefinedValue(values: Array<string | undefined>): string | undefined {
+  return values.find((value) => value !== undefined);
+}
+
+export function resolveOAuthUsername(profile: OAuthProfile): string {
+  const usernameClaimValues = USERNAME_CLAIM_PRIORITY.map((claim) =>
+    getClaim(profile, claim),
+  );
+  const username = firstDefinedValue([
+    ...usernameClaimValues,
+    getEmailLocalPart(getClaim(profile, 'email')),
+    getEmailLocalPart(getClaim(profile, 'upn')),
+    getUsernameFromProfileUrl(getClaim(profile, 'profile')),
+    getClaim(profile, 'sub'),
+  ]);
+  return username ?? '';
+}
+
+export function resolveOAuthDisplayName(
+  profile: OAuthProfile,
+  fallbackUsername: string,
+): string {
+  const trimmedFallbackUsername = fallbackUsername.trim();
+  const displayName = firstDefinedValue([
+    getClaim(profile, 'name'),
+    getClaim(profile, 'preferred_username'),
+    getClaim(profile, 'username'),
+    getClaim(profile, 'nickname'),
+    getClaim(profile, 'login'),
+    trimmedFallbackUsername.length > 0 ? trimmedFallbackUsername : undefined,
+  ]);
+  return displayName ?? '';
+}
+
+export function resolveOAuthProfileUrl(
+  profile: OAuthProfile,
+): string | undefined {
+  const profileClaimValues = PROFILE_URL_CLAIM_PRIORITY.map((claim) =>
+    getClaim(profile, claim),
+  );
+  return firstDefinedValue(profileClaimValues);
+}

--- a/client/src/util/auth/oauthUserProfile.ts
+++ b/client/src/util/auth/oauthUserProfile.ts
@@ -36,14 +36,19 @@ function getUsernameFromProfileUrl(
   if (!profileUrl) {
     return undefined;
   }
-  let pathname: string;
+  let path: string;
   try {
-    pathname = new URL(profileUrl).pathname;
+    path = new URL(profileUrl).pathname;
   } catch {
-    return undefined;
+    // Relative path (e.g. /group/user or example/user) — only proceed if it looks like a path
+    const rawPath = profileUrl.split('?')[0]?.split('#')[0] ?? '';
+    if (!rawPath.includes('/')) {
+      return undefined;
+    }
+    path = rawPath;
   }
-  const pathSegments = pathname.split('/').filter(Boolean);
-  const username = pathSegments.at(-1)?.trim();
+  const pathSegments = path.split('/').filter(Boolean);
+  const username = pathSegments[pathSegments.length - 1]?.trim();
   return username && username.length > 0 ? username : undefined;
 }
 

--- a/client/test/__mocks__/mockEnvConstants.ts
+++ b/client/test/__mocks__/mockEnvConstants.ts
@@ -27,7 +27,7 @@ export const mockUser: mockUserType = {
     groups: 'group-one',
     picture: 'pfp.jpg',
     preferred_username: 'username',
-    profile: 'example/username',
+    profile: 'https://example.com/username',
   },
 };
 

--- a/client/test/integration/Auth/authRedux.test.tsx
+++ b/client/test/integration/Auth/authRedux.test.tsx
@@ -6,6 +6,7 @@ import Library from 'route/library/Library';
 import authReducer from 'store/auth.slice';
 import { mockUser } from 'test/__mocks__/global_mocks';
 import { renderWithRouter } from 'test/unit/unit.testUtil';
+import { resolveOAuthUsername } from 'util/auth/oauthUserProfile';
 
 jest.mock('components/route/Snackbar', () => ({
   __esModule: true,
@@ -46,7 +47,7 @@ const setupTest = (authState: AuthState) => {
   if (authState.isAuthenticated) {
     store.dispatch({
       type: 'auth/setUserName',
-      payload: mockUser.profile.profile!.split('/')[1],
+      payload: resolveOAuthUsername(mockUser.profile),
     });
   } else {
     store.dispatch({ type: 'auth/setUserName', payload: undefined });

--- a/client/test/integration/integration.testUtil.tsx
+++ b/client/test/integration/integration.testUtil.tsx
@@ -21,6 +21,7 @@ import { ExecutionStatus } from 'model/backend/interfaces/execution';
 import executionHistoryReducer, {
   addExecutionHistoryEntry,
 } from 'model/backend/state/executionHistory.slice';
+import { resolveOAuthUsername } from 'util/auth/oauthUserProfile';
 
 export const normalizer = getDefaultNormalizer({
   trim: false,
@@ -99,7 +100,7 @@ export async function setupIntegrationTest(
   if (returnedAuthState.isAuthenticated) {
     store.dispatch({
       type: 'auth/setUserName',
-      payload: returnedAuthState.user!.profile.profile!.split('/')[1],
+      payload: resolveOAuthUsername(returnedAuthState.user?.profile),
     });
   } else {
     store.dispatch({ type: 'auth/setUserName', payload: undefined });

--- a/client/test/integration/jest.setup.ts
+++ b/client/test/integration/jest.setup.ts
@@ -6,7 +6,7 @@ import 'test/__mocks__/global_mocks';
 import { TextEncoder, TextDecoder } from 'node:util';
 
 globalThis.TextEncoder = TextEncoder;
-globalThis.TextDecoder = TextDecoder;
+globalThis.TextDecoder = TextDecoder as unknown as typeof globalThis.TextDecoder;
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/client/test/integration/jest.setup.ts
+++ b/client/test/integration/jest.setup.ts
@@ -6,7 +6,8 @@ import 'test/__mocks__/global_mocks';
 import { TextEncoder, TextDecoder } from 'node:util';
 
 globalThis.TextEncoder = TextEncoder;
-globalThis.TextDecoder = TextDecoder as unknown as typeof globalThis.TextDecoder;
+globalThis.TextDecoder =
+  TextDecoder as unknown as typeof globalThis.TextDecoder;
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/client/test/unit/jest.setup.ts
+++ b/client/test/unit/jest.setup.ts
@@ -8,7 +8,7 @@ import 'test/__mocks__/unit/module_mocks';
 import { TextEncoder, TextDecoder } from 'node:util';
 
 globalThis.TextEncoder = TextEncoder;
-globalThis.TextDecoder = TextDecoder;
+globalThis.TextDecoder = TextDecoder as unknown as typeof globalThis.TextDecoder;
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/client/test/unit/jest.setup.ts
+++ b/client/test/unit/jest.setup.ts
@@ -8,7 +8,8 @@ import 'test/__mocks__/unit/module_mocks';
 import { TextEncoder, TextDecoder } from 'node:util';
 
 globalThis.TextEncoder = TextEncoder;
-globalThis.TextDecoder = TextDecoder as unknown as typeof globalThis.TextDecoder;
+globalThis.TextDecoder =
+  TextDecoder as unknown as typeof globalThis.TextDecoder;
 
 beforeEach(() => {
   jest.clearAllMocks();

--- a/client/test/unit/routes/Account.test.tsx
+++ b/client/test/unit/routes/Account.test.tsx
@@ -154,7 +154,7 @@ describe('AccountTabs', () => {
       profile: { ...accountMockUser.profile, profile: undefined },
     };
     (useAuth as jest.Mock).mockReturnValue({ user: userWithoutProfileUrl });
-    render(<Account />);
+    renderWithRouter(<Account />, { route: '/private' });
 
     expect(
       screen.getByText(/Your OAuth provider did not expose a profile URL/),

--- a/client/test/unit/routes/Account.test.tsx
+++ b/client/test/unit/routes/Account.test.tsx
@@ -147,4 +147,17 @@ describe('AccountTabs', () => {
       '<b>username</b> belongs to <b>g1</b>, <b>g2</b>, <b>g3</b>, <b>g4</b> and <b>g5</b> groups.',
     );
   });
+
+  test('renders AccountTabs with fallback text when OAuth provider exposes no profile URL', () => {
+    const userWithoutProfileUrl = {
+      ...accountMockUser,
+      profile: { ...accountMockUser.profile, profile: undefined },
+    };
+    (useAuth as jest.Mock).mockReturnValue({ user: userWithoutProfileUrl });
+    render(<Account />);
+
+    expect(
+      screen.getByText(/Your OAuth provider did not expose a profile URL/),
+    ).toBeInTheDocument();
+  });
 });

--- a/client/test/unit/unit.testUtil.tsx
+++ b/client/test/unit/unit.testUtil.tsx
@@ -15,6 +15,11 @@ import { Store } from 'redux';
 import userEvent from '@testing-library/user-event';
 import routes from 'routes';
 import { mockUserType } from 'test/__mocks__/global_mocks';
+import {
+  resolveOAuthDisplayName,
+  resolveOAuthProfileUrl,
+  resolveOAuthUsername,
+} from 'util/auth/oauthUserProfile';
 
 type RouterOptions = {
   route?: string;
@@ -225,17 +230,23 @@ export function testStaticAccountProfile(mockUser: mockUserType) {
   expect(profilePicture).toBeInTheDocument();
   expect(profilePicture).toHaveAttribute('src', mockUser.profile.picture);
 
-  const username = screen.getAllByText(
-    `${mockUser.profile.preferred_username}`,
+  const resolvedUsername = resolveOAuthUsername(mockUser.profile);
+  const displayName = resolveOAuthDisplayName(
+    mockUser.profile,
+    resolvedUsername,
   );
-  expect(username).not.toBeNull();
-  expect(username).toHaveLength(2);
+  const usernames = screen.getAllByText(`${displayName}`);
+  expect(usernames).not.toBeNull();
+  expect(usernames).toHaveLength(2);
 
   const profileLink = screen.getByRole('link', {
     name: /SSO OAuth Provider/i,
   });
   expect(profileLink).toBeInTheDocument();
-  expect(profileLink).toHaveAttribute('href', mockUser.profile.profile);
+  expect(profileLink).toHaveAttribute(
+    'href',
+    resolveOAuthProfileUrl(mockUser.profile),
+  );
 }
 
 export async function testAccountSettings(mockUser: mockUserType) {
@@ -248,7 +259,7 @@ export async function testAccountSettings(mockUser: mockUserType) {
     const settingsParagraph = screen.getByText(/Edit the profile on/);
     expect(settingsParagraph).toHaveProperty(
       'innerHTML',
-      `Edit the profile on <b><a href="${mockUser.profile.profile}">SSO OAuth Provider.</a></b>`,
+      `Edit the profile on <b><a href="${resolveOAuthProfileUrl(mockUser.profile)}">SSO OAuth Provider.</a></b>`,
     );
   });
 

--- a/client/test/unit/unit.testUtil.tsx
+++ b/client/test/unit/unit.testUtil.tsx
@@ -16,7 +16,6 @@ import userEvent from '@testing-library/user-event';
 import routes from 'routes';
 import { mockUserType } from 'test/__mocks__/global_mocks';
 import {
-  resolveOAuthDisplayName,
   resolveOAuthProfileUrl,
   resolveOAuthUsername,
 } from 'util/auth/oauthUserProfile';
@@ -230,12 +229,8 @@ export function testStaticAccountProfile(mockUser: mockUserType) {
   expect(profilePicture).toBeInTheDocument();
   expect(profilePicture).toHaveAttribute('src', mockUser.profile.picture);
 
-  const resolvedUsername = resolveOAuthUsername(mockUser.profile);
-  const displayName = resolveOAuthDisplayName(
-    mockUser.profile,
-    resolvedUsername,
-  );
-  const usernames = screen.getAllByText(`${displayName}`);
+  const expectedUsername = resolveOAuthUsername(mockUser.profile);
+  const usernames = screen.getAllByText(expectedUsername);
   expect(usernames).not.toBeNull();
   expect(usernames).toHaveLength(2);
 

--- a/client/test/unit/util/Auth/Authentication.test.ts
+++ b/client/test/unit/util/Auth/Authentication.test.ts
@@ -1,8 +1,19 @@
-import { useSignOut } from 'util/auth/Authentication';
+import {
+  CustomAuthContext,
+  useSignOut,
+  useGetAndSetUsername,
+} from 'util/auth/Authentication';
 import { useAuth } from 'react-oidc-context';
 import { getLogoutRedirectURI, useAppURL, cleanURL } from 'util/envUtil';
+import { setUserName } from 'store/auth.slice';
+import { useDispatch } from 'react-redux';
+import { User } from 'oidc-client-ts';
 
 jest.mock('react-oidc-context');
+jest.mock('react-redux', () => ({
+  ...jest.requireActual('react-redux'),
+  useDispatch: jest.fn(),
+}));
 jest.mock('util/envUtil', () => ({
   getLogoutRedirectURI: jest.fn(),
   useAppURL: jest.fn(),
@@ -147,5 +158,77 @@ describe('useSignOut', () => {
     await signOut(auth);
 
     expect(mockClear).toHaveBeenCalled();
+  });
+});
+
+describe('useGetAndSetUsername', () => {
+  const mockDispatch = jest.fn();
+  const mockSignoutRedirect = jest.fn(async () => {});
+  const mockRemoveUser = jest.fn(async () => {});
+  const mockSignoutSilent = jest.fn(async () => {});
+  const mockRevokeTokens = jest.fn(async () => {});
+
+  beforeEach(() => {
+    (useDispatch as unknown as jest.Mock).mockReturnValue(mockDispatch);
+    jest.spyOn(Storage.prototype, 'setItem').mockImplementation(jest.fn());
+    mockDispatch.mockReset();
+  });
+
+  it('extracts username from preferred_username for keycloak style profile', () => {
+    const getAndSetUsername = useGetAndSetUsername();
+    getAndSetUsername({
+      signoutRedirect: mockSignoutRedirect,
+      removeUser: mockRemoveUser,
+      signoutSilent: mockSignoutSilent,
+      revokeTokens: mockRevokeTokens,
+      user: {
+        profile: {
+          preferred_username: 'kc-user',
+          sub: '123',
+        },
+      } as unknown as User,
+    } as CustomAuthContext);
+
+    expect(sessionStorage.setItem).toHaveBeenCalledWith('username', 'kc-user');
+    expect(mockDispatch).toHaveBeenCalledWith(setUserName('kc-user'));
+  });
+
+  it('extracts username from profile URL for gitlab style profile', () => {
+    const getAndSetUsername = useGetAndSetUsername();
+    getAndSetUsername({
+      signoutRedirect: mockSignoutRedirect,
+      removeUser: mockRemoveUser,
+      signoutSilent: mockSignoutSilent,
+      revokeTokens: mockRevokeTokens,
+      user: {
+        profile: {
+          profile: 'https://gitlab.example.com/example-user',
+        },
+      } as unknown as User,
+    } as CustomAuthContext);
+
+    expect(sessionStorage.setItem).toHaveBeenCalledWith(
+      'username',
+      'example-user',
+    );
+    expect(mockDispatch).toHaveBeenCalledWith(setUserName('example-user'));
+  });
+
+  it('extracts username from email local part for dex style profile', () => {
+    const getAndSetUsername = useGetAndSetUsername();
+    getAndSetUsername({
+      signoutRedirect: mockSignoutRedirect,
+      removeUser: mockRemoveUser,
+      signoutSilent: mockSignoutSilent,
+      revokeTokens: mockRevokeTokens,
+      user: {
+        profile: {
+          email: 'dex-user@example.com',
+        },
+      } as unknown as User,
+    } as CustomAuthContext);
+
+    expect(sessionStorage.setItem).toHaveBeenCalledWith('username', 'dex-user');
+    expect(mockDispatch).toHaveBeenCalledWith(setUserName('dex-user'));
   });
 });

--- a/client/test/unit/util/Auth/oauthUserProfile.test.ts
+++ b/client/test/unit/util/Auth/oauthUserProfile.test.ts
@@ -52,13 +52,19 @@ describe('oauthUserProfile', () => {
     });
 
     it('returns empty string when profile URL has no path segments (bare domain)', () => {
-      expect(resolveOAuthUsername({ profile: 'https://idp.example.com/' })).toBe(
-        '',
-      );
+      expect(
+        resolveOAuthUsername({ profile: 'https://idp.example.com/' }),
+      ).toBe('');
     });
 
-    it('returns empty string when profile claim is not a valid URL', () => {
+    it('returns empty string when profile claim is not a valid URL and contains no path separator', () => {
       expect(resolveOAuthUsername({ profile: 'not-a-valid-url' })).toBe('');
+    });
+
+    it('resolves username from relative profile path', () => {
+      expect(resolveOAuthUsername({ profile: 'example/username' })).toBe(
+        'username',
+      );
     });
   });
 

--- a/client/test/unit/util/Auth/oauthUserProfile.test.ts
+++ b/client/test/unit/util/Auth/oauthUserProfile.test.ts
@@ -1,0 +1,87 @@
+import {
+  resolveOAuthDisplayName,
+  resolveOAuthProfileUrl,
+  resolveOAuthUsername,
+} from 'util/auth/oauthUserProfile';
+
+describe('oauthUserProfile', () => {
+  describe('resolveOAuthUsername', () => {
+    it('resolves username from preferred_username for keycloak profiles', () => {
+      expect(
+        resolveOAuthUsername({
+          preferred_username: 'kc-user',
+          sub: 'uuid-123',
+        }),
+      ).toBe('kc-user');
+    });
+
+    it('resolves username from profile URL for gitlab profiles', () => {
+      expect(
+        resolveOAuthUsername({
+          profile: 'https://gitlab.example.com/group/gitlab-user',
+        }),
+      ).toBe('gitlab-user');
+    });
+
+    it('resolves username from email local part for dex profiles', () => {
+      expect(
+        resolveOAuthUsername({
+          email: 'dex-user@example.com',
+        }),
+      ).toBe('dex-user');
+    });
+
+    it('falls back to sub claim when no other claim is available', () => {
+      expect(
+        resolveOAuthUsername({
+          sub: 'subject-only',
+        }),
+      ).toBe('subject-only');
+    });
+
+    it('returns empty string when no usable claims are available', () => {
+      expect(resolveOAuthUsername({})).toBe('');
+    });
+  });
+
+  describe('resolveOAuthDisplayName', () => {
+    it('prefers name over username-style claims', () => {
+      expect(
+        resolveOAuthDisplayName(
+          {
+            name: 'Jane Doe',
+            preferred_username: 'jane',
+          },
+          'fallback-user',
+        ),
+      ).toBe('Jane Doe');
+    });
+
+    it('uses fallback username when no display claims are available', () => {
+      expect(resolveOAuthDisplayName({}, 'fallback-user')).toBe('fallback-user');
+    });
+  });
+
+  describe('resolveOAuthProfileUrl', () => {
+    it('resolves profile claim when present', () => {
+      expect(
+        resolveOAuthProfileUrl({
+          profile: 'https://idp.example.com/account',
+          html_url: 'https://github.com/user',
+        }),
+      ).toBe('https://idp.example.com/account');
+    });
+
+    it('falls back to html_url when profile is absent', () => {
+      expect(
+        resolveOAuthProfileUrl({
+          html_url: 'https://github.com/user',
+        }),
+      ).toBe('https://github.com/user');
+    });
+
+    it('returns undefined when no profile URL is exposed', () => {
+      expect(resolveOAuthProfileUrl({})).toBeUndefined();
+    });
+  });
+});

--- a/client/test/unit/util/Auth/oauthUserProfile.test.ts
+++ b/client/test/unit/util/Auth/oauthUserProfile.test.ts
@@ -58,7 +58,9 @@ describe('oauthUserProfile', () => {
     });
 
     it('uses fallback username when no display claims are available', () => {
-      expect(resolveOAuthDisplayName({}, 'fallback-user')).toBe('fallback-user');
+      expect(resolveOAuthDisplayName({}, 'fallback-user')).toBe(
+        'fallback-user',
+      );
     });
   });
 
@@ -82,6 +84,14 @@ describe('oauthUserProfile', () => {
 
     it('returns undefined when no profile URL is exposed', () => {
       expect(resolveOAuthProfileUrl({})).toBeUndefined();
+    });
+
+    it('returns undefined for unsafe URL schemes', () => {
+      expect(
+        resolveOAuthProfileUrl({
+          profile: 'data:text/plain;base64,Zm9v',
+        }),
+      ).toBeUndefined();
     });
   });
 });

--- a/client/test/unit/util/Auth/oauthUserProfile.test.ts
+++ b/client/test/unit/util/Auth/oauthUserProfile.test.ts
@@ -50,6 +50,16 @@ describe('oauthUserProfile', () => {
     it('returns empty string for undefined profile', () => {
       expect(resolveOAuthUsername(undefined)).toBe('');
     });
+
+    it('returns empty string when profile URL has no path segments (bare domain)', () => {
+      expect(resolveOAuthUsername({ profile: 'https://idp.example.com/' })).toBe(
+        '',
+      );
+    });
+
+    it('returns empty string when profile claim is not a valid URL', () => {
+      expect(resolveOAuthUsername({ profile: 'not-a-valid-url' })).toBe('');
+    });
   });
 
   describe('resolveOAuthDisplayName', () => {

--- a/client/test/unit/util/Auth/oauthUserProfile.test.ts
+++ b/client/test/unit/util/Auth/oauthUserProfile.test.ts
@@ -42,6 +42,14 @@ describe('oauthUserProfile', () => {
     it('returns empty string when no usable claims are available', () => {
       expect(resolveOAuthUsername({})).toBe('');
     });
+
+    it('returns empty string for null profile', () => {
+      expect(resolveOAuthUsername(null)).toBe('');
+    });
+
+    it('returns empty string for undefined profile', () => {
+      expect(resolveOAuthUsername(undefined)).toBe('');
+    });
   });
 
   describe('resolveOAuthDisplayName', () => {
@@ -90,6 +98,14 @@ describe('oauthUserProfile', () => {
       expect(
         resolveOAuthProfileUrl({
           profile: 'data:text/plain;base64,Zm9v',
+        }),
+      ).toBeUndefined();
+    });
+
+    it('returns undefined for malformed URLs', () => {
+      expect(
+        resolveOAuthProfileUrl({
+          profile: 'not-a-valid-url',
         }),
       ).toBeUndefined();
     });

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -4,7 +4,7 @@
     "allowSyntheticDefaultImports": true, //allow default imports from modules with no default export
     "sourceMap": true, //generate .map files
     "target": "es6", //target es6
-    "lib": ["ES6", "DOM", "DOM.Iterable", "ES2022.Error"], //include ES2022.Error for ErrorOptions
+    "lib": ["ES6", "DOM", "DOM.Iterable", "ES2022.Error", "ES2022.Array"], //include ES2022.Error for ErrorOptions and ES2022.Array for Array.at()
     "jsx": "react-jsx", //use react jsx runtime (required for React 19)
     "types": ["react", "node", "jest"], //use react, node and jest types
     "module": "esnext", //use esnext modules

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -4,7 +4,7 @@
     "allowSyntheticDefaultImports": true, //allow default imports from modules with no default export
     "sourceMap": true, //generate .map files
     "target": "es6", //target es6
-    "lib": ["ES6", "DOM", "DOM.Iterable", "ES2022.Error", "ES2022.Array"], //include ES2022.Error for ErrorOptions and ES2022.Array for Array.at()
+    "lib": ["ES6", "DOM", "DOM.Iterable", "ES2022.Error"], //include ES2022.Error for ErrorOptions
     "jsx": "react-jsx", //use react jsx runtime (required for React 19)
     "types": ["react", "node", "jest"], //use react, node and jest types
     "module": "esnext", //use esnext modules

--- a/docs/admin/client/auth.md
+++ b/docs/admin/client/auth.md
@@ -67,3 +67,22 @@ User accounts must be created in GitLab for all usernames chosen during
 installation. The _trial_ installation script includes two default
 usernames - _user1_ and _user2_. For all other installation scenarios,
 accounts with specific usernames must be created on GitLab.
+
+## Username claim resolution for OIDC providers
+
+DTaaS resolves the logged-in username from common OIDC claims so that
+multiple providers are supported (e.g., GitLab, Keycloak, Dex).
+
+The client checks claims in this order:
+
+1. `preferred_username`
+2. `username`
+3. `nickname`
+4. `login`
+5. local part of `email` (before `@`)
+6. local part of `upn` (before `@`)
+7. last path segment of `profile` URL (GitLab-compatible fallback)
+8. `sub`
+
+This order preserves existing GitLab behavior while allowing providers
+that do not expose `profile` URLs to authenticate correctly.

--- a/docs/developer/technical-concepts/OAUTH_LOGIN.md
+++ b/docs/developer/technical-concepts/OAUTH_LOGIN.md
@@ -1,0 +1,130 @@
+# OAuth Username Resolution in the React Client
+
+## The Problem
+
+The client had a single, GitLab-specific method for extracting the
+logged-in username in `Authentication.ts`:
+
+```typescript
+const profileUrl = auth.user.profile.profile ?? '';
+const username = profileUrl.split('/').filter(Boolean).pop() ?? '';
+```
+
+This assumed the OIDC provider always exposes a `profile` claim
+containing a URL whose last path segment is the username — the pattern
+GitLab uses (`https://gitlab.example.com/username`). It fails silently
+for any other provider:
+
+- **Keycloak**: exposes `preferred_username`, not a profile URL
+- **Dex** (native): exposes `preferred_username`, not a profile URL —
+  which is why a companion Python proxy was built to inject a synthetic
+  `profile` URL as a workaround
+- **Any OIDC provider without a `profile` URL**: username becomes `""`
+  with no error
+
+The same hardcoded assumption existed in `AccountTabData.tsx` for
+display and linking purposes.
+
+## The Solution: a provider-agnostic resolver module
+
+The fix introduces `client/src/util/auth/oauthUserProfile.ts` — a
+single module that centralises all claim resolution logic. It exports
+three functions:
+
+### `resolveOAuthUsername(profile)`
+
+Walks a fixed priority chain and returns the first usable value:
+
+```
+1. preferred_username   ← Keycloak, Dex, most OIDC
+2. username             ← some custom providers
+3. nickname             ← OpenID standard optional claim
+4. login                ← GitHub-style providers
+5. local part of email  ← Dex connector fallback (e.g. "alice" from "alice@example.com")
+6. local part of upn    ← Azure AD / Entra ID
+7. last path segment of profile URL  ← GitLab (preserves old behaviour)
+8. sub                  ← worst-case fallback, always present
+```
+
+The chain is ordered by reliability and specificity, with GitLab's
+URL-based extraction demoted to step 7 (still present for backward
+compatibility) and `sub` as the final safety net so the function always
+returns a non-empty string if any claim exists.
+
+### `resolveOAuthProfileUrl(profile)`
+
+Looks for `profile` then `html_url` (GitHub). It runs the candidate
+through `isSafeExternalUrl()` before returning — a security check that
+rejects anything that is not `http:` or `https:`, preventing XSS via
+`javascript:` or `data:` URLs injected into the `href` of the profile
+link. Returns `undefined` rather than an unsafe URL.
+
+### `resolveOAuthDisplayName(profile, fallbackUsername)`
+
+Prefers the OIDC `name` claim (full name, e.g. "Jane Doe") over
+username-style claims. Used where a human-readable display name is more
+appropriate than a login handle.
+
+## How callers changed
+
+**`Authentication.ts` — `useGetAndSetUsername`**
+
+The three lines of GitLab-specific URL parsing are replaced by a single
+call:
+
+```typescript
+// before
+const profileUrl = auth.user.profile.profile ?? '';
+const username = profileUrl.split('/').filter(Boolean).pop() ?? '';
+sessionStorage.setItem('username', username ?? '');
+
+// after
+const username = resolveOAuthUsername(auth.user.profile);
+sessionStorage.setItem('username', username);
+```
+
+This is where the username gets written to Redux state and
+`sessionStorage` — the centralised point that feeds the rest of the
+application.
+
+**`AccountTabData.tsx` — `ProfileTab` and `SettingsTab`**
+
+Both components now call the same resolver functions. When the provider
+does not expose a profile URL (Keycloak default, Dex without companion),
+the UI shows "Your OAuth provider did not expose a profile URL." instead
+of rendering a broken link:
+
+```typescript
+{profileUrl ? profileSettingsText : profileNotAvailableText}
+```
+
+## Internal module structure
+
+`oauthUserProfile.ts` is built from small, single-purpose private
+functions:
+
+- **`getClaim`** — safely reads a string claim from the profile, trims
+  it, returns `undefined` for missing/non-string/empty values
+- **`getEmailLocalPart`** — splits on `@` and returns the local part
+- **`getUsernameFromProfileUrl`** — strips query/fragment, splits on
+  `/`, returns the last segment
+- **`isSafeExternalUrl`** — uses `new URL()` for parsing (no regex),
+  allows only `http:` and `https:`
+- **`firstDefinedValue`** — walks an array and returns the first
+  non-undefined entry; drives the priority chain in `resolveOAuthUsername`
+
+All five are unexported. The module's public surface is exactly the
+three `resolve*` functions.
+
+## Effect on provider-specific infrastructure
+
+The Dex companion Python service
+(`deploy/workspace/dex/localhost/companion/`) existed solely to paper
+over the old code's GitLab assumption. It intercepted `/dex/userinfo`
+responses and injected a synthetic `profile` URL of the form
+`{issuer}/{preferred_username}` so that the GitLab-specific path parser
+could extract the username.
+
+With `preferred_username` now checked first, Keycloak and Dex both
+resolve usernames directly from standard claims. The companion service
+is no longer required for username resolution.

--- a/docs/developer/technical-concepts/OAUTH_LOGIN.md
+++ b/docs/developer/technical-concepts/OAUTH_LOGIN.md
@@ -35,7 +35,7 @@ three functions:
 
 Walks a fixed priority chain and returns the first usable value:
 
-```
+```text
 1. preferred_username   ← Keycloak, Dex, most OIDC
 2. username             ← some custom providers
 3. nickname             ← OpenID standard optional claim


### PR DESCRIPTION
## Summary
- implement provider-agnostic OIDC claim resolver for username extraction
- wire resolver into auth username initialization and account display/profile-link logic
- add unit/integration coverage for GitLab, Keycloak, and Dex-like claim patterns
- document username claim priority for OAuth/OIDC providers

## Validation
- cd client && yarn syntax
- cd client && yarn test:unit
- cd client && yarn build

Resolves https://github.com/INTO-CPS-Association/DTaaS/issues/1543
