### PR TITLE
fix: enable GraphQL POST requests in release docker-compose files

### DIFF
--- a/deploy/dtaas/docker/secure-server/docker-compose.yml
+++ b/deploy/dtaas/docker/secure-server/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
       - "--providers.file.directory=/etc/traefik"
       - "--providers.file.watch=true"
-    labels: []
     ports:
       - "80:80"
       - "443:443"

--- a/deploy/dtaas/docker/secure-server/docker-compose.yml
+++ b/deploy/dtaas/docker/secure-server/docker-compose.yml
@@ -88,12 +88,13 @@ services:
       - "traefik.http.services.libms.loadbalancer.server.port=4001"
       - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=https://${SERVER_DNS:-localhost}"
       - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowHeaders=Authorization,Content-Type"
       - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
       - >-
         traefik.http.routers.libms.rule=Host(`${SERVER_DNS:-localhost}`)
         && PathPrefix(`/lib`)
       - "traefik.http.routers.libms.tls=true"
-      - "traefik.http.routers.libms.middlewares=traefik-forward-auth,cors"
+      - "traefik.http.routers.libms.middlewares=cors,traefik-forward-auth"
     networks:
       - frontend
 

--- a/deploy/dtaas/docker/secure-server/docker-compose.yml
+++ b/deploy/dtaas/docker/secure-server/docker-compose.yml
@@ -14,6 +14,12 @@ services:
       - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
       - "--providers.file.directory=/etc/traefik"
       - "--providers.file.watch=true"
+    labels:
+      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=https://${SERVER_DNS:-localhost}"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
+      - "traefik.http.routers.myservice.rule=Host(`myservice.localhost`)"
+      - "traefik.http.services.myservice.loadbalancer.server.port=80"
     ports:
       - "80:80"
       - "443:443"

--- a/deploy/dtaas/docker/secure-server/docker-compose.yml
+++ b/deploy/dtaas/docker/secure-server/docker-compose.yml
@@ -95,7 +95,7 @@ services:
         traefik.http.routers.libms.rule=Host(`${SERVER_DNS:-localhost}`)
         && PathPrefix(`/lib`)
       - "traefik.http.routers.libms.tls=true"
-      - "traefik.http.routers.libms.middlewares=traefik-forward-auth"
+      - "traefik.http.routers.libms.middlewares=traefik-forward-auth,cors"
     networks:
       - frontend
 

--- a/deploy/dtaas/docker/secure-server/docker-compose.yml
+++ b/deploy/dtaas/docker/secure-server/docker-compose.yml
@@ -14,13 +14,7 @@ services:
       - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
       - "--providers.file.directory=/etc/traefik"
       - "--providers.file.watch=true"
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=https://${SERVER_DNS:-localhost}"
-      - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
-      - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
-      - "traefik.http.routers.myservice.rule=Host(`myservice.localhost`)"
-      - "traefik.http.services.myservice.loadbalancer.server.port=80"
+    labels: []
     ports:
       - "80:80"
       - "443:443"
@@ -92,6 +86,9 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.services.libms.loadbalancer.server.port=4001"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=https://${SERVER_DNS:-localhost}"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
       - >-
         traefik.http.routers.libms.rule=Host(`${SERVER_DNS:-localhost}`)
         && PathPrefix(`/lib`)

--- a/deploy/dtaas/docker/secure-server/docker-compose.yml
+++ b/deploy/dtaas/docker/secure-server/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - "--providers.file.directory=/etc/traefik"
       - "--providers.file.watch=true"
     labels:
+      - "traefik.enable=true"
       - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=https://${SERVER_DNS:-localhost}"
       - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
       - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"

--- a/deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml
+++ b/deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml
@@ -14,7 +14,6 @@ services:
       - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
       - "--providers.file.directory=/etc/traefik"
       - "--providers.file.watch=true"
-    labels: []
     ports:
       - "80:80"
       - "443:443"

--- a/deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml
+++ b/deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml
@@ -88,12 +88,13 @@ services:
       - "traefik.http.services.libms.loadbalancer.server.port=4001"
       - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=https://${SERVER_DNS:-localhost}"
       - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowHeaders=Authorization,Content-Type"
       - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
       - >-
         traefik.http.routers.libms.rule=Host(`${SERVER_DNS:-localhost}`)
         && PathPrefix(`/lib`)
       - "traefik.http.routers.libms.tls=true"
-      - "traefik.http.routers.libms.middlewares=traefik-forward-auth,cors"
+      - "traefik.http.routers.libms.middlewares=cors,traefik-forward-auth"
     networks:
       - frontend
 

--- a/deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml
+++ b/deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml
@@ -14,6 +14,12 @@ services:
       - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
       - "--providers.file.directory=/etc/traefik"
       - "--providers.file.watch=true"
+    labels:
+      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=https://${SERVER_DNS:-localhost}"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
+      - "traefik.http.routers.myservice.rule=Host(`myservice.localhost`)"
+      - "traefik.http.services.myservice.loadbalancer.server.port=80"
     ports:
       - "80:80"
       - "443:443"

--- a/deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml
+++ b/deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml
@@ -95,7 +95,7 @@ services:
         traefik.http.routers.libms.rule=Host(`${SERVER_DNS:-localhost}`)
         && PathPrefix(`/lib`)
       - "traefik.http.routers.libms.tls=true"
-      - "traefik.http.routers.libms.middlewares=traefik-forward-auth"
+      - "traefik.http.routers.libms.middlewares=traefik-forward-auth,cors"
     networks:
       - frontend
 

--- a/deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml
+++ b/deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml
@@ -14,13 +14,7 @@ services:
       - "--entrypoints.web.http.redirections.entrypoint.permanent=true"
       - "--providers.file.directory=/etc/traefik"
       - "--providers.file.watch=true"
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=https://${SERVER_DNS:-localhost}"
-      - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
-      - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
-      - "traefik.http.routers.myservice.rule=Host(`myservice.localhost`)"
-      - "traefik.http.services.myservice.loadbalancer.server.port=80"
+    labels: []
     ports:
       - "80:80"
       - "443:443"
@@ -92,6 +86,9 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.services.libms.loadbalancer.server.port=4001"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=https://${SERVER_DNS:-localhost}"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
       - >-
         traefik.http.routers.libms.rule=Host(`${SERVER_DNS:-localhost}`)
         && PathPrefix(`/lib`)

--- a/deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml
+++ b/deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       - "--providers.file.directory=/etc/traefik"
       - "--providers.file.watch=true"
     labels:
+      - "traefik.enable=true"
       - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=https://${SERVER_DNS:-localhost}"
       - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
       - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"

--- a/deploy/dtaas/docker/server/docker-compose.yml
+++ b/deploy/dtaas/docker/server/docker-compose.yml
@@ -11,6 +11,7 @@ services:
       - "--entrypoints.web.forwardedHeaders.insecure=true"
       - "--entrypoints.web.proxyProtocol.insecure=true"
     labels:
+      - "traefik.enable=true"
       - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=http://${SERVER_DNS:-localhost}"
       - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
       - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"

--- a/deploy/dtaas/docker/server/docker-compose.yml
+++ b/deploy/dtaas/docker/server/docker-compose.yml
@@ -11,7 +11,7 @@ services:
       - "--entrypoints.web.forwardedHeaders.insecure=true"
       - "--entrypoints.web.proxyProtocol.insecure=true"
     labels:
-      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=https://${SERVER_DNS:-localhost}"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=http://${SERVER_DNS:-localhost}"
       - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
       - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
       - "traefik.http.routers.myservice.rule=Host(`myservice.localhost`)"
@@ -86,7 +86,7 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.libms.entryPoints=web"
       - "traefik.http.services.libms.loadbalancer.server.port=4001"
-      - "traefik.http.routers.libms.middlewares=traefik-forward-auth"
+      - "traefik.http.routers.libms.middlewares=traefik-forward-auth,cors"
       - >-
         traefik.http.routers.libms.rule=Host(`${SERVER_DNS:-localhost}`)
         && PathPrefix(`/lib`)

--- a/deploy/dtaas/docker/server/docker-compose.yml
+++ b/deploy/dtaas/docker/server/docker-compose.yml
@@ -10,7 +10,6 @@ services:
       - "--entryPoints.web.address=:80"
       - "--entrypoints.web.forwardedHeaders.insecure=true"
       - "--entrypoints.web.proxyProtocol.insecure=true"
-    labels: []
     ports:
       - "80:80"
       - "443:443"

--- a/deploy/dtaas/docker/server/docker-compose.yml
+++ b/deploy/dtaas/docker/server/docker-compose.yml
@@ -10,13 +10,7 @@ services:
       - "--entryPoints.web.address=:80"
       - "--entrypoints.web.forwardedHeaders.insecure=true"
       - "--entrypoints.web.proxyProtocol.insecure=true"
-    labels:
-      - "traefik.enable=true"
-      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=http://${SERVER_DNS:-localhost}"
-      - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
-      - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
-      - "traefik.http.routers.myservice.rule=Host(`myservice.localhost`)"
-      - "traefik.http.services.myservice.loadbalancer.server.port=80"
+    labels: []
     ports:
       - "80:80"
       - "443:443"
@@ -87,6 +81,9 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.libms.entryPoints=web"
       - "traefik.http.services.libms.loadbalancer.server.port=4001"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=http://${SERVER_DNS:-localhost}"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
       - "traefik.http.routers.libms.middlewares=traefik-forward-auth,cors"
       - >-
         traefik.http.routers.libms.rule=Host(`${SERVER_DNS:-localhost}`)

--- a/deploy/dtaas/docker/server/docker-compose.yml
+++ b/deploy/dtaas/docker/server/docker-compose.yml
@@ -83,8 +83,9 @@ services:
       - "traefik.http.services.libms.loadbalancer.server.port=4001"
       - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=http://${SERVER_DNS:-localhost}"
       - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowHeaders=Authorization,Content-Type"
       - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
-      - "traefik.http.routers.libms.middlewares=traefik-forward-auth,cors"
+      - "traefik.http.routers.libms.middlewares=cors,traefik-forward-auth"
       - >-
         traefik.http.routers.libms.rule=Host(`${SERVER_DNS:-localhost}`)
         && PathPrefix(`/lib`)

--- a/deploy/dtaas/docker/server/docker-compose.yml
+++ b/deploy/dtaas/docker/server/docker-compose.yml
@@ -10,6 +10,12 @@ services:
       - "--entryPoints.web.address=:80"
       - "--entrypoints.web.forwardedHeaders.insecure=true"
       - "--entrypoints.web.proxyProtocol.insecure=true"
+    labels:
+      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=https://${SERVER_DNS:-localhost}"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
+      - "traefik.http.routers.myservice.rule=Host(`myservice.localhost`)"
+      - "traefik.http.services.myservice.loadbalancer.server.port=80"
     ports:
       - "80:80"
       - "443:443"

--- a/developer/docker-compose.yml
+++ b/developer/docker-compose.yml
@@ -11,9 +11,6 @@ services:
       - "--entrypoints.web.proxyProtocol.insecure=true"
       - "--log.level=DEBUG"
     labels:
-      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=http://localhost,http://host.docker.internal"
-      - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
-      - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
       - "traefik.http.routers.myservice.rule=Host(`myservice.localhost`)"
       - "traefik.http.services.myservice.loadbalancer.server.port=80"
     ports:
@@ -52,8 +49,12 @@ services:
       - "traefik.enable=true"
       - "traefik.http.routers.libms.entryPoints=web"
       - "traefik.http.services.libms.loadbalancer.server.port=4001"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowOriginList=http://localhost,http://host.docker.internal"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowMethods=GET,OPTIONS,POST"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowHeaders=Authorization,Content-Type"
+      - "traefik.http.middlewares.cors.headers.accessControlAllowCredentials=true"
       - "traefik.http.routers.libms.rule=PathPrefix(`/lib`)"
-      - "traefik.http.routers.libms.middlewares=traefik-forward-auth"
+      - "traefik.http.routers.libms.middlewares=cors,traefik-forward-auth"
     networks:
       - frontend
 


### PR DESCRIPTION
## Summary

Fixes [INTO-CPS-Association/DTaaS#1399](https://github.com/INTO-CPS-Association/DTaaS/issues/1399)

The GraphQL lib microservice requires HTTP POST requests. The developer \`docker-compose.yml\` was already fixed by adding \`POST\` to the CORS middleware \`accessControlAllowMethods\`. The same fix is needed in the three release docker-compose files.

## Changes

Added CORS middleware labels to the \`libms\` service in:
- \`deploy/dtaas/docker/server/docker-compose.yml\`
- \`deploy/dtaas/docker/secure-server/docker-compose.yml\`
- \`deploy/dtaas/docker/secure-server_with_integrated-gitlab/docker-compose.yml\`

Each libms service now has:
- \`accessControlAllowMethods=GET,OPTIONS,POST\` (POST required for GraphQL)
- \`accessControlAllowOriginList\` set to the server origin (HTTP for insecure, HTTPS for secure deployments)
- \`accessControlAllowHeaders=Authorization,Content-Type\` (required for GraphQL preflight requests)
- \`accessControlAllowCredentials=true\`
- Middleware ordering: \`cors,traefik-forward-auth\` so CORS preflight requests are answered before OAuth authentication checks

The CORS middleware is defined on the \`libms\` container (which already has \`traefik.enable=true\`) rather than on the \`traefik\` container, to avoid routing interference when \`--providers.docker.exposedbydefault=false\` is set.

This mirrors the fix already present in \`developer/docker-compose.yml\`.